### PR TITLE
Accept -e to specify git_tag and git_sha1 from command line

### DIFF
--- a/s3d
+++ b/s3d
@@ -23,6 +23,7 @@ function displayHelpText {
     s3d <config-file>
       -h, display this message
       -f, force upload without asking for confirmation
+      -e (git_tag|git_sha1)=VAL sets path variable to VAL
       -v, display version
 \n
 EOF
@@ -47,7 +48,10 @@ function confirm {
 
 path="$(readlink $DIR/s3d | xargs dirname )"
 
-while getopts "hvf" opt; do
+git_tag=""
+git_sha1=""
+
+while getopts "hvfe:" opt; do
   case "$opt" in 
     h)
       displayHelpText
@@ -60,6 +64,17 @@ while getopts "hvf" opt; do
     f)
       ignore_confirm=true
       ;;
+    e)
+      if [[ $OPTARG =~ ^git_tag=(.+)$ ]]; then
+        git_tag=${BASH_REMATCH[1]}
+        echo -e "\$git_tag = ${git_tag}"
+      elif [[ $OPTARG =~ ^git_sha1=(.+)$ ]]; then
+        git_sha1=${BASH_REMATCH[1]}
+        echo -e "\$git_sha1 = ${git_sha1}"
+      else
+        echo "Could not match -e param. Must be of form (git_tag|git_sha1)=VAL"
+      fi
+      ;;
   esac
 done
 
@@ -69,8 +84,8 @@ if [ ! $1 ] ; then
   exit 0
 fi
 
-$path/scripts/plan.rb $1
+$path/scripts/plan.rb $1 $git_tag $git_sha1
 if [ ! $ignore_confirm ] ; then
   confirm
 fi
-$path/scripts/execute.rb $1
+$path/scripts/execute.rb $1 $git_tag $git_sha1

--- a/scripts/execute.rb
+++ b/scripts/execute.rb
@@ -3,7 +3,7 @@
 dir = File.expand_path(File.dirname(__FILE__))
 require "#{dir}/shared.rb"
 
-cf = ConfigFile.new(ARGV.first)
+cf = ConfigFile.new(ARGV[0], ARGV[1], ARGV[2])
 
 output = `aws s3 sync #{cf.upload_dir} s3://#{cf.bucket_name}#{cf.bucket_path} --acl public-read #{cf.bucket_options}`
 

--- a/scripts/plan.rb
+++ b/scripts/plan.rb
@@ -3,7 +3,7 @@
 dir = File.expand_path(File.dirname(__FILE__))
 require "#{dir}/shared.rb"
 
-cf = ConfigFile.new(ARGV.first)
+cf = ConfigFile.new(ARGV[0], ARGV[1], ARGV[2])
 
 # Colors
 GREEN="\033[0;32m"

--- a/test/shared_test.rb
+++ b/test/shared_test.rb
@@ -48,16 +48,22 @@ EOM
     File.delete(@tmp_file)
   }
 
-  subject { ConfigFile.new(@tmp_file) }
+  context "using git" do
+    subject { ConfigFile.new(@tmp_file) }
 
-  its(:upload_dir) { should == "#{PROJECT_ROOT}/build"}
-  its(:aws_account) { should == "my-prod-user"}
-  its(:aws_keyfile) { should == ".aws.prodkeys"}
-  its(:bucket_name) { should == "name.of.my.bucket"}
-  its(:bucket_path) { should == "/project/#{git_tag}-#{git_sha1}"}
-  its(:cdns) do
-    should == {"cloudfront" => "https://b33fgotm11k.cloudfront.net", "akamai" => "https://e9474.b.akamaiedge.net" }
+    its(:upload_dir) { should == "#{PROJECT_ROOT}/build"}
+    its(:aws_account) { should == "my-prod-user"}
+    its(:aws_keyfile) { should == ".aws.prodkeys"}
+    its(:bucket_name) { should == "name.of.my.bucket"}
+    its(:bucket_path) { should == "/project/#{git_tag}-#{git_sha1}"}
+    its(:cdns) do
+      should == {"cloudfront" => "https://b33fgotm11k.cloudfront.net", "akamai" => "https://e9474.b.akamaiedge.net" }
+    end
   end
 
+  context "supplying git_tag and git_sha1" do
+    subject { ConfigFile.new(@tmp_file, '7', '12345') }
+    its(:bucket_path) { should == "/project/7-12345"}
+  end
 end
 


### PR DESCRIPTION
For deployboard we don't have a `.git` directory so this lets us supply when we call s3d.

@will-ob could you do me a favor and check my ruby? Am I doing anything stupid or non-rubyish?
