### PR TITLE
DMCMP-229 Add ability to upload a single file with config["upload"]["file"]

### DIFF
--- a/scripts/execute.rb
+++ b/scripts/execute.rb
@@ -5,7 +5,7 @@ require "#{dir}/shared.rb"
 
 cf = ConfigFile.new(ARGV[0], ARGV[1], ARGV[2])
 
-output = `aws s3 sync #{cf.upload_dir} s3://#{cf.bucket_name}#{cf.bucket_path} --acl public-read #{cf.bucket_options}`
+output = `aws s3 #{cf.command} #{cf.upload_dir} s3://#{cf.bucket_name}#{cf.bucket_path} --acl public-read #{cf.bucket_options}`
 
 puts output
 

--- a/test/shared_test.rb
+++ b/test/shared_test.rb
@@ -56,6 +56,7 @@ EOM
     its(:aws_keyfile) { should == ".aws.prodkeys"}
     its(:bucket_name) { should == "name.of.my.bucket"}
     its(:bucket_path) { should == "/project/#{git_tag}-#{git_sha1}"}
+    its(:command) { should == "sync"}
     its(:cdns) do
       should == {"cloudfront" => "https://b33fgotm11k.cloudfront.net", "akamai" => "https://e9474.b.akamaiedge.net" }
     end


### PR DESCRIPTION
DMCMP-229

`config["upload"]["div"]` takes precedence.
Raises error if `["upload"]["div"]` or `["upload"]["file"]` is mising.
